### PR TITLE
Changing Py3 Shebang

### DIFF
--- a/BingRewards/BingRewards.py
+++ b/BingRewards/BingRewards.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/env python3
 
 import os
 import getpass


### PR DESCRIPTION
I encountered trouble running this on my Ubuntu instance, did some digging and found that a generally recommended way to find / define the interpreter is to do it this way. It also fixed my problem running the files.

Some discussion here: https://stackoverflow.com/questions/7670303/purpose-of-usr-bin-python3